### PR TITLE
fix(lad): render trolleybus emoji for live vehicle_type

### DIFF
--- a/functions/bus-lviv-bot/format/vehicle-emoji.ts
+++ b/functions/bus-lviv-bot/format/vehicle-emoji.ts
@@ -1,0 +1,20 @@
+import { Vehicle } from '../types/vehicle';
+import { logger } from '../logger';
+
+// Record (not Partial<Record>) so adding a Vehicle member without an emoji is a compile error.
+const VEHICLE_EMOJI: Record<Vehicle, string> = {
+  [Vehicle.BUS]: '\u{1F68C}',
+  [Vehicle.TRAM]: '\u{1F68B}',
+  [Vehicle.TROLLEYBUS]: '\u{1F68E}',
+};
+
+export const convertVehicleTypeToEmoji = (vehicleType: Vehicle): string => {
+  // Annotated as possibly undefined on purpose: the API response is not validated at runtime,
+  // so an unknown vehicle_type can reach this despite the parameter type.
+  const emoji: string | undefined = VEHICLE_EMOJI[vehicleType];
+  if (emoji === undefined) {
+    logger.warn('Unknown vehicle_type, falling back to no emoji', { vehicleType });
+    return '';
+  }
+  return emoji;
+};

--- a/functions/bus-lviv-bot/index.ts
+++ b/functions/bus-lviv-bot/index.ts
@@ -1,4 +1,3 @@
-import { Logger } from '@aws-lambda-powertools/logger';
 import { Context, Telegraf } from 'telegraf';
 import { start } from './middleware/start';
 import { help } from './middleware/help';
@@ -8,8 +7,7 @@ import { lad } from './middleware/lad';
 import { token } from './config/config';
 import { APIGatewayProxyEventV2 } from 'aws-lambda';
 import { Update } from '@telegraf/types/update';
-
-export const logger = new Logger({ serviceName: 'bus-lviv-bot' });
+import { logger } from './logger';
 
 const bot = new Telegraf(token);
 

--- a/functions/bus-lviv-bot/logger.ts
+++ b/functions/bus-lviv-bot/logger.ts
@@ -1,0 +1,3 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+
+export const logger = new Logger({ serviceName: 'bus-lviv-bot' });

--- a/functions/bus-lviv-bot/middleware/lad.ts
+++ b/functions/bus-lviv-bot/middleware/lad.ts
@@ -4,6 +4,7 @@ import { bold, code, fmt } from 'telegraf/format';
 import { apiUrl } from '../config/config';
 import { Context } from 'telegraf';
 import { Message } from '@telegraf/types/message';
+import { convertVehicleTypeToEmoji } from '../format/vehicle-emoji';
 
 export const lad = async (ctx: Context) => {
   const message = ctx.message as Message.TextMessage;
@@ -44,18 +45,4 @@ ${code(stop.name)}
 ${routes}
 /${stop.code}
 `;
-};
-
-const convertVehicleTypeToEmoji = (vehicleType: string) => {
-  switch (vehicleType) {
-    case 'bus':
-    case 'marshrutka':
-      return '\u{1F68C}';
-    case 'tram':
-      return '\u{1F68B}';
-    case 'trol':
-      return '\u{1F68E}';
-    default:
-      return '';
-  }
 };

--- a/functions/bus-lviv-bot/types/vehicle.ts
+++ b/functions/bus-lviv-bot/types/vehicle.ts
@@ -1,5 +1,6 @@
+// Values must match `timetable[].vehicle_type` as returned by GET /stops/{id}.
 export enum Vehicle {
   TRAM = 'tram',
   BUS = 'bus',
-  TROL = 'trol',
+  TROLLEYBUS = 'trolleybus',
 }

--- a/test/vehicle-emoji.spec.ts
+++ b/test/vehicle-emoji.spec.ts
@@ -1,0 +1,38 @@
+import { convertVehicleTypeToEmoji } from '../functions/bus-lviv-bot/format/vehicle-emoji';
+import { Vehicle } from '../functions/bus-lviv-bot/types/vehicle';
+
+// vehicle_type values observed in live GET /stops/{id} responses:
+//   'bus'        -> А05, А09, А16, ...
+//   'tram'       -> Т02, Т03, Т04, ...
+//   'trolleybus' -> Т22, Т23, Т25, ... (named Тр22/Тр23 in routes.json)
+const LIVE_API_VEHICLE_TYPES = ['bus', 'tram', 'trolleybus'];
+
+describe('convertVehicleTypeToEmoji', () => {
+  it.each([
+    [Vehicle.BUS, '\u{1F68C}'],
+    [Vehicle.TRAM, '\u{1F68B}'],
+    [Vehicle.TROLLEYBUS, '\u{1F68E}'],
+  ])('maps %s to %s', (vehicleType, expected) => {
+    expect(convertVehicleTypeToEmoji(vehicleType)).toBe(expected);
+  });
+
+  // Regression: the enum used 'trol' while the API sends 'trolleybus', so every
+  // trolleybus arrival rendered without an emoji.
+  it('renders an emoji for the trolleybus value the API actually sends', () => {
+    expect(convertVehicleTypeToEmoji('trolleybus' as Vehicle)).toBe('\u{1F68E}');
+  });
+
+  it('covers every vehicle_type the live API returns', () => {
+    expect(Object.values<string>(Vehicle).sort()).toEqual(LIVE_API_VEHICLE_TYPES.sort());
+  });
+
+  it('returns an emoji for every Vehicle member', () => {
+    for (const vehicleType of Object.values(Vehicle)) {
+      expect(convertVehicleTypeToEmoji(vehicleType)).not.toBe('');
+    }
+  });
+
+  it('falls back to an empty string for an unknown vehicle type', () => {
+    expect(convertVehicleTypeToEmoji('funicular' as Vehicle)).toBe('');
+  });
+});


### PR DESCRIPTION
`Vehicle` used `trol`, but `GET /stops/{id}` returns `trolleybus` — so every trolleybus arrival rendered with no emoji.

Fixed the enum value, moved the mapping to a `Record<Vehicle, string>` (a missing mapping now fails to compile), and added tests for the three live values (`bus`, `tram`, `trolleybus`).