### PR TITLE
feat(lad): rework stop message and fix response types

### DIFF
--- a/functions/bus-lviv-bot/format/stop-message.ts
+++ b/functions/bus-lviv-bot/format/stop-message.ts
@@ -1,0 +1,70 @@
+import { bold, fmt, FmtString } from 'telegraf/format';
+import { Stop } from '../types/stop';
+import { Timetable } from '../types/timetable';
+import { Transfer } from '../types/transfer';
+import { Vehicle } from '../types/vehicle';
+import { convertVehicleTypeToEmoji } from './vehicle-emoji';
+
+const STOP_SIGN = '\u{1F68F}';
+const NO_REALTIME_DATA = '\u{23F1} Наразі даних у реальному часі немає.';
+const TRANSFERS_HEADER = 'Тут зазвичай ходять:';
+const LOWFLOOR_MARK = '\u{267F}';
+
+// Trams, then trolleybuses, then buses.
+const VEHICLE_ORDER: Record<Vehicle, number> = {
+  [Vehicle.TRAM]: 0,
+  [Vehicle.TROLLEYBUS]: 1,
+  [Vehicle.BUS]: 2,
+};
+
+const vehicleOrder = (vehicleType: Vehicle): number => {
+  const order: number | undefined = VEHICLE_ORDER[vehicleType];
+  return order ?? Number.MAX_SAFE_INTEGER;
+};
+
+// 'time_left' is a display string such as '9хв' or '< 1хв'.
+const parseEtaMinutes = (timeLeft: string): number => {
+  const digits = /\d+/.exec(timeLeft);
+  return digits ? Number(digits[0]) : Number.MAX_SAFE_INTEGER;
+};
+
+// One line per arrival, soonest first. Repeat visits of the same route stay separate lines.
+const renderArrival = (arrival: Timetable): string => {
+  const emoji = convertVehicleTypeToEmoji(arrival.vehicle_type);
+  const accessible = arrival.lowfloor ? ` ${LOWFLOOR_MARK}` : '';
+  const destination = arrival.end_stop_name || arrival.end_stop;
+  const head = `${emoji} ${arrival.route} - ${arrival.time_left}`;
+
+  // Skip the trailing stop sign entirely when the terminus is unknown.
+  return destination ? `${head} - ${STOP_SIGN} ${destination}${accessible}` : `${head}${accessible}`;
+};
+
+// Static routes serving the stop, used when there is no realtime data to show.
+const renderTransfers = (transfers: readonly Transfer[]): string[] => {
+  const routesByVehicle = new Map<Vehicle, Set<string>>();
+  for (const transfer of transfers) {
+    const routes = routesByVehicle.get(transfer.vehicle_type) ?? new Set<string>();
+    routes.add(transfer.route);
+    routesByVehicle.set(transfer.vehicle_type, routes);
+  }
+
+  if (routesByVehicle.size === 0) {
+    return [];
+  }
+
+  const lines = [...routesByVehicle.entries()]
+    .sort(([a], [b]) => vehicleOrder(a) - vehicleOrder(b))
+    .map(([vehicleType, routes]) => `  ${convertVehicleTypeToEmoji(vehicleType)} ${[...routes].sort().join(', ')}`);
+
+  return [TRANSFERS_HEADER, ...lines];
+};
+
+export const buildStopMessage = (stop: Stop): FmtString => {
+  const arrivals = stop.timetable ?? [];
+  const body =
+    arrivals.length > 0
+      ? [...arrivals].sort((a, b) => parseEtaMinutes(a.time_left) - parseEtaMinutes(b.time_left)).map(renderArrival)
+      : [NO_REALTIME_DATA, ...renderTransfers(stop.transfers ?? [])];
+
+  return fmt`${bold(`${STOP_SIGN} ${stop.name} · ${stop.code}`)}\n\n${body.join('\n')}\n\n/${stop.code}`;
+};

--- a/functions/bus-lviv-bot/middleware/lad.ts
+++ b/functions/bus-lviv-bot/middleware/lad.ts
@@ -1,10 +1,9 @@
 import axios from 'axios';
 import { Stop } from '../types/stop';
-import { bold, code, fmt } from 'telegraf/format';
 import { apiUrl } from '../config/config';
 import { Context } from 'telegraf';
 import { Message } from '@telegraf/types/message';
-import { convertVehicleTypeToEmoji } from '../format/vehicle-emoji';
+import { buildStopMessage } from '../format/stop-message';
 
 export const lad = async (ctx: Context) => {
   const message = ctx.message as Message.TextMessage;
@@ -15,8 +14,7 @@ export const lad = async (ctx: Context) => {
   }
   try {
     const stop: Stop = await fetchStop(stopId);
-    const markdown = getMessageMarkdown(stop);
-    await ctx.reply(markdown, {
+    await ctx.reply(buildStopMessage(stop), {
       reply_parameters: { message_id: message.message_id },
     });
   } catch (error) {
@@ -30,19 +28,4 @@ const fetchStop = async (stopId: number) => {
     timeout: 5000,
   });
   return response.data as Stop;
-};
-
-const getMessageMarkdown = (stop: Stop) => {
-  const timetable = stop.timetable;
-  let routes = '';
-  timetable?.forEach(route => {
-    routes += `${convertVehicleTypeToEmoji(route.vehicle_type)} ${route.route} - ${route.time_left} - \u{1F68F} ${route.end_stop}\n`;
-  });
-  return fmt`
-${bold(stop.code)}
-${code(stop.name)}
-------------------------------
-${routes}
-/${stop.code}
-`;
 };

--- a/functions/bus-lviv-bot/types/stop.ts
+++ b/functions/bus-lviv-bot/types/stop.ts
@@ -4,6 +4,7 @@ import { Transfer } from './transfer';
 export interface Stop {
   code: number;
   name: string;
+  eng_name?: string;
   longitude: number;
   latitude: number;
   transfers?: Transfer[];

--- a/functions/bus-lviv-bot/types/timetable.ts
+++ b/functions/bus-lviv-bot/types/timetable.ts
@@ -7,12 +7,12 @@ export interface Timetable {
   arrival_time: string;
   time_left: string;
   vehicle_id: string;
-  location: string[];
+  location: [number, number];
   bearing: number;
   color: string;
   vehicle_type: Vehicle;
   shape_id: string;
-  direction: number;
+  direction: number | null;
   direction_id: number;
   end_stop: string;
   end_stop_name: string;

--- a/test/stop-message.spec.ts
+++ b/test/stop-message.spec.ts
@@ -1,0 +1,197 @@
+import { buildStopMessage } from '../functions/bus-lviv-bot/format/stop-message';
+import { Stop } from '../functions/bus-lviv-bot/types/stop';
+import { Timetable } from '../functions/bus-lviv-bot/types/timetable';
+import { Transfer } from '../functions/bus-lviv-bot/types/transfer';
+import { Vehicle } from '../functions/bus-lviv-bot/types/vehicle';
+
+const TRAM = '\u{1F68B}';
+const BUS = '\u{1F68C}';
+const STOP_SIGN = '\u{1F68F}';
+const LOWFLOOR = '\u{267F}';
+
+// Fixtures mirror GET /stops/35 («Саксаганського») field for field.
+const arrival = (overrides: Partial<Timetable>): Timetable => ({
+  route: 'Т03',
+  route_id: '972',
+  lowfloor: false,
+  arrival_time: 'Mon, 27 Jul 2026 19:51:20 GMT',
+  time_left: '3хв',
+  vehicle_id: '3304',
+  location: [49.82973, 24.02661],
+  bearing: 71,
+  color: '#50B056',
+  vehicle_type: Vehicle.TRAM,
+  shape_id: '20199',
+  direction: null,
+  direction_id: 0,
+  end_stop: 'Соборна',
+  end_stop_name: 'Соборна',
+  end_stop_eng_name: 'Soborna square',
+  end_stop_code: 74,
+  ...overrides,
+});
+
+const transfer = (overrides: Partial<Transfer>): Transfer => ({
+  id: '2464',
+  color: '#0E4F95',
+  route: 'А53',
+  vehicle_type: Vehicle.BUS,
+  shape_id: '20212',
+  direction_id: 0,
+  end_stop_name: 'Галицьке перехрестя',
+  end_stop_eng_name: 'Avtobudivelnykiv',
+  end_stop_code: 741,
+  ...overrides,
+});
+
+const stop = (overrides: Partial<Stop>): Stop => ({
+  code: 35,
+  name: 'Саксаганського',
+  eng_name: 'Saksahanskoho',
+  latitude: 49.834422,
+  longitude: 24.034339,
+  ...overrides,
+});
+
+// The live timetable of stop 35: Т03 and Т08 each arrive twice.
+const liveArrivals = (): Timetable[] => [
+  arrival({ route: 'Т03', time_left: '3хв' }),
+  arrival({ route: 'Т08', time_left: '13хв' }),
+  arrival({ route: 'Т03', time_left: '18хв' }),
+  arrival({ route: 'Т08', time_left: '20хв' }),
+];
+
+// The live transfers of stop 35: three tram routes and one bus route.
+const liveTransfers = (): Transfer[] => [
+  transfer({ route: 'А53', vehicle_type: Vehicle.BUS, end_stop_code: 741 }),
+  transfer({ route: 'Т03', vehicle_type: Vehicle.TRAM, end_stop_name: 'Соборна', end_stop_code: 74 }),
+  transfer({ route: 'Т08', vehicle_type: Vehicle.TRAM, end_stop_name: 'Соборна', end_stop_code: 74 }),
+  transfer({ route: 'Т09', vehicle_type: Vehicle.TRAM, end_stop_name: 'Торф’яна', end_stop_code: 704 }),
+];
+
+const arrivalLines = (text: string): string[] => text.split('\n').filter(line => line.includes(' - '));
+
+describe('buildStopMessage', () => {
+  it('renders the stop name and code in the header', () => {
+    const message = buildStopMessage(stop({ timetable: liveArrivals() }));
+    expect(message.text).toContain(`${STOP_SIGN} Саксаганського · 35`);
+  });
+
+  it('renders one line per arrival in the "route - time - stop" form', () => {
+    const message = buildStopMessage(stop({ timetable: [arrival({ route: 'Т03', time_left: '3хв' })] }));
+    expect(message.text).toContain(`${TRAM} Т03 - 3хв - ${STOP_SIGN} Соборна`);
+  });
+
+  it('lists repeat arrivals of the same route on separate lines', () => {
+    const message = buildStopMessage(stop({ timetable: liveArrivals() }));
+    expect(arrivalLines(message.text)).toEqual([
+      `${TRAM} Т03 - 3хв - ${STOP_SIGN} Соборна`,
+      `${TRAM} Т08 - 13хв - ${STOP_SIGN} Соборна`,
+      `${TRAM} Т03 - 18хв - ${STOP_SIGN} Соборна`,
+      `${TRAM} Т08 - 20хв - ${STOP_SIGN} Соборна`,
+    ]);
+  });
+
+  it('does not group: no "через" wording and no comma-joined times', () => {
+    const message = buildStopMessage(stop({ timetable: liveArrivals() }));
+    expect(message.text).not.toContain('через');
+    expect(message.text).not.toContain('3, 18');
+    expect(message.text).not.toContain('13, 20');
+  });
+
+  it('sorts every arrival by soonest, interleaving routes', () => {
+    const message = buildStopMessage(
+      stop({
+        timetable: [
+          arrival({ route: 'Т03', time_left: '18хв' }),
+          arrival({ route: 'Т08', time_left: '13хв' }),
+          arrival({ route: 'Т03', time_left: '3хв' }),
+          arrival({ route: 'Т08', time_left: '20хв' }),
+        ],
+      }),
+    );
+    expect(arrivalLines(message.text).map(line => /(\d+)хв/.exec(line)?.[1])).toEqual(['3', '13', '18', '20']);
+  });
+
+  it('sorts the "< 1хв" form ahead of numbered minutes', () => {
+    const message = buildStopMessage(
+      stop({ timetable: [arrival({ time_left: '18хв' }), arrival({ time_left: '< 1хв' })] }),
+    );
+    expect(message.text.indexOf('< 1хв')).toBeLessThan(message.text.indexOf('18хв'));
+  });
+
+  it('marks a low-floor vehicle at the end of its own line only', () => {
+    const message = buildStopMessage(
+      stop({
+        timetable: [
+          arrival({ route: 'Т03', time_left: '3хв', lowfloor: true }),
+          arrival({ route: 'Т08', time_left: '13хв' }),
+        ],
+      }),
+    );
+    expect(arrivalLines(message.text)).toEqual([
+      `${TRAM} Т03 - 3хв - ${STOP_SIGN} Соборна ${LOWFLOOR}`,
+      `${TRAM} Т08 - 13хв - ${STOP_SIGN} Соборна`,
+    ]);
+  });
+
+  it('falls back to end_stop when end_stop_name is empty', () => {
+    const message = buildStopMessage(stop({ timetable: [arrival({ end_stop_name: '', end_stop: 'Соборна' })] }));
+    expect(message.text).toContain(`- ${STOP_SIGN} Соборна`);
+  });
+
+  it('omits the dangling stop sign when the terminus is unknown', () => {
+    const message = buildStopMessage(
+      stop({
+        timetable: [
+          arrival({ route: 'А32', vehicle_type: Vehicle.BUS, time_left: '40хв', end_stop_name: '', end_stop: '' }),
+        ],
+      }),
+    );
+    expect(message.text).toContain(`${BUS} А32 - 40хв`);
+    expect(message.text).not.toContain(`40хв - ${STOP_SIGN}`);
+  });
+
+  it('falls back to the routes serving the stop when there is no realtime data', () => {
+    const message = buildStopMessage(stop({ timetable: [], transfers: liveTransfers() }));
+    expect(message.text).toContain('Наразі даних у реальному часі немає.');
+    expect(message.text).toContain('Тут зазвичай ходять:');
+    // trams before buses, routes sorted within each mode
+    expect(message.text).toContain(`${TRAM} Т03, Т08, Т09`);
+    expect(message.text).toContain(`${BUS} А53`);
+    expect(message.text.indexOf('Т03')).toBeLessThan(message.text.indexOf('А53'));
+  });
+
+  it('de-duplicates routes that appear in transfers more than once', () => {
+    const message = buildStopMessage(
+      stop({
+        timetable: [],
+        transfers: [
+          transfer({ route: 'Т03', vehicle_type: Vehicle.TRAM, direction_id: 0 }),
+          transfer({ route: 'Т03', vehicle_type: Vehicle.TRAM, direction_id: 1 }),
+        ],
+      }),
+    );
+    expect(message.text.match(/Т03/g)).toHaveLength(1);
+  });
+
+  it('never leaks a terminus stop code as a tappable number', () => {
+    const message = buildStopMessage(stop({ timetable: liveArrivals(), transfers: liveTransfers() }));
+    expect(message.text).not.toContain('/74');
+    expect(message.text).not.toContain('/741');
+    expect(message.text).not.toContain('/704');
+    // only the stop's own code is tappable
+    expect(message.text).toContain('/35');
+  });
+
+  it('handles a stop with neither timetable nor transfers', () => {
+    const message = buildStopMessage(stop({}));
+    expect(message.text).toContain('Наразі даних у реальному часі немає.');
+    expect(message.text).not.toContain('Тут зазвичай ходять:');
+  });
+
+  it('bolds the header', () => {
+    const message = buildStopMessage(stop({ timetable: liveArrivals() }));
+    expect(message.entities).toEqual(expect.arrayContaining([expect.objectContaining({ type: 'bold', offset: 0 })]));
+  });
+});


### PR DESCRIPTION
Every arrival on its own line sorted by ETA, ♿ for low-floor vehicles, and a fallback to the routes serving the stop when there is no realtime data.

Also fixes three types that did not match the API: `location` (number pair), `direction` (nullable), `Stop.eng_name`.