### PR TITLE
fix(lad): tell the user when a stop number does not exist

### DIFF
--- a/functions/bus-lviv-bot/api/errors.ts
+++ b/functions/bus-lviv-bot/api/errors.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+// openapi.yaml documents 404 for an unknown stop code and 404 for an unknown vehicle id.
+// A 404 means the resource will never exist, so it is a user-facing answer rather than a fault.
+export const isNotFoundError = (error: unknown): boolean => axios.isAxiosError(error) && error.response?.status === 404;

--- a/functions/bus-lviv-bot/middleware/lad.ts
+++ b/functions/bus-lviv-bot/middleware/lad.ts
@@ -4,12 +4,20 @@ import { apiUrl } from '../config/config';
 import { Context } from 'telegraf';
 import { Message } from '@telegraf/types/message';
 import { buildStopMessage } from '../format/stop-message';
+import { isNotFoundError } from '../api/errors';
+import { logger } from '../logger';
+
+const INVALID_STOP_ID = 'Будь ласка, введіть коректний номер зупинки (позитивне число).';
+const FETCH_FAILED = 'Вибачте, сталася помилка при отриманні інформації про зупинку. Спробуйте пізніше.';
+
+const stopNotFound = (stopId: number) =>
+  `Зупинки з номером ${stopId} не знайдено. Перевірте номер на табличці або надішліть свою локацію, щоб знайти найближчі зупинки.`;
 
 export const lad = async (ctx: Context) => {
   const message = ctx.message as Message.TextMessage;
   const stopId: number = parseInt(message.text.replace('/', ''));
   if (isNaN(stopId) || stopId <= 0) {
-    await ctx.reply('Будь ласка, введіть коректний номер зупинки (позитивне число).');
+    await ctx.reply(INVALID_STOP_ID);
     return;
   }
   try {
@@ -18,8 +26,14 @@ export const lad = async (ctx: Context) => {
       reply_parameters: { message_id: message.message_id },
     });
   } catch (error) {
-    console.error('Error fetching stop:', error);
-    await ctx.reply('Вибачте, сталася помилка при отриманні інформації про зупинку. Спробуйте пізніше.');
+    // A wrong stop number is a normal user mistake, not a failure worth alerting on.
+    if (isNotFoundError(error)) {
+      logger.info('Stop not found', { stopId });
+      await ctx.reply(stopNotFound(stopId));
+      return;
+    }
+    logger.error('Error fetching stop', { stopId, error });
+    await ctx.reply(FETCH_FAILED);
   }
 };
 

--- a/test/api-errors.spec.ts
+++ b/test/api-errors.spec.ts
@@ -1,0 +1,37 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { isNotFoundError } from '../functions/bus-lviv-bot/api/errors';
+
+const axiosErrorWithStatus = (status: number): AxiosError =>
+  new AxiosError('Request failed', 'ERR_BAD_REQUEST', undefined, undefined, {
+    status,
+    statusText: '',
+    data: {},
+    headers: {},
+    config: { headers: {} },
+  } as AxiosResponse);
+
+describe('isNotFoundError', () => {
+  // GET /stops/999999 answers 404 (verified against api.lad.lviv.ua).
+  it('is true for a 404 response', () => {
+    expect(isNotFoundError(axiosErrorWithStatus(404))).toBe(true);
+  });
+
+  it.each([400, 429, 500, 502, 503])('is false for a %i response', status => {
+    expect(isNotFoundError(axiosErrorWithStatus(status))).toBe(false);
+  });
+
+  // Timeouts and DNS failures carry no response at all — those must stay retryable.
+  it('is false for a network error with no response', () => {
+    expect(isNotFoundError(new AxiosError('timeout of 5000ms exceeded', 'ECONNABORTED'))).toBe(false);
+  });
+
+  it.each([
+    ['a plain Error', new Error('boom')],
+    ['a string', 'not found'],
+    ['null', null],
+    ['undefined', undefined],
+    ['an object that only looks like a response', { response: { status: 404 } }],
+  ])('is false for %s', (_label, value) => {
+    expect(isNotFoundError(value)).toBe(false);
+  });
+});


### PR DESCRIPTION
The API answers 404 for an unknown stop code, but every failure got the same "try again later" reply — advice that can never work for a wrong number.

Now a 404 gets its own message and is logged at info, so a user typo no longer looks like an application fault.