### PR TITLE
chore(deps): bump transitive brace-expansion to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6033,9 +6033,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Closes Dependabot alert [#47](https://github.com/sturman/bus-lviv-bot/security/dependabot/47) — brace-expansion DoS, GHSA-3jxr-9vmj-r5cp / CVE-2026-13149, high, development scope.

## Where it came from

One vulnerable copy, reached only through `jest`:

```
jest@30.4.2 (devDependency)
└─ @jest/core@30.4.2
   ├─ @jest/reporters@30.4.1  ┐
   ├─ jest-config@30.4.2      ├─ all three → glob@10.5.0 (deduped)
   └─ jest-runtime@30.4.2     ┘
      └─ glob@10.5.0
         └─ minimatch@9.0.9
            └─ brace-expansion@2.1.0   ← vulnerable, needs ≥ 2.1.2
```

Every other copy in the tree was already on a patched version: `eslint` → `minimatch@10.2.6` → 5.0.8, `semantic-release` → `npm` → 5.0.7, and `ts-jest` → `test-exclude` → `minimatch@3.1.5` → 1.1.16 (the fixed 1.x).

## What changed

`npm update brace-expansion --package-lock-only` — three lines in `package-lock.json`, a single entry, nothing else:

- `glob/node_modules/brace-expansion` 2.1.0 → **2.1.2**

`minimatch@9.0.9` declares `brace-expansion: ^2.0.2`, so 2.1.2 satisfies the existing range — no `package.json` change, no `overrides`, no jest bump.

`npm audit fix --force` was **not** used: it proposes `jest@25.0.0` and `ts-jest@29.1.2`, i.e. major downgrades.

> Originally this PR also carried the top-level dev copy 5.0.7 → 5.0.8. That landed on `main` independently as a side effect of #484 (eslint 10.8.0), so after rebasing onto `main` the change here narrowed to the one vulnerable entry.

## Not covered here

Alert [#46](https://github.com/sturman/bus-lviv-bot/security/dependabot/46) is the same advisory against `brace-expansion@5.0.6` **bundled inside** `aws-cdk-lib@2.261.0`. Because it ships inside the tarball, neither `npm update` nor `overrides` can reach it — the only fix is bumping `aws-cdk-lib` (2.262.1 bundles the patched 5.0.7). Left for a separate PR since it touches a runtime dependency and will produce a CDK diff.

## Test plan

Re-run in full after rebasing onto `main` at 25066ad, which pulled in eslint 10.8.0, ts-jest 29.4.12 and aws-cdk 2.1133.0:

- [x] `npm ci` — clean install from the merged lockfile
- [x] `npm install --package-lock-only` — **zero diff**, confirming the auto-merged lockfile is exactly what npm's resolver produces for the merged `package.json` (a clean textual merge of a lockfile is not by itself proof of a coherent one)
- [x] `npm run ts-check` — pass
- [x] `npm run eslint` — pass, against the newly bumped eslint 10.8.0
- [x] `npm run test` — 37/37 across 4 suites
- [x] `npm ls brace-expansion --all` — 2.1.2 resolved under glob; all five copies now patched except the bundled aws-cdk-lib one noted above
- [ ] CI green on this PR

`npm run prettier:check:ci` flags only `.claude/settings.local.json`, which is gitignored and absent in CI.
