### PR TITLE
chore(deps): bump aws-cdk-lib from 2.261.0 to 2.262.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "@aws-lambda-powertools/logger": "^2.34.0",
         "@types/aws-lambda": "^8.10.162",
-        "aws-cdk-lib": "2.261.0",
+        "aws-cdk-lib": "2.262.1",
         "axios": "^1.18.1",
         "constructs": "^10.7.1",
         "source-map-support": "^0.5.21",
@@ -104,9 +104,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
-      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
+      "version": "54.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.14.0.tgz",
+      "integrity": "sha512-JCZCzgp3SuXQVljaKqXnttHzcezEHt9Ag/YipK0XwUFD+Iz2T4jY7gUc3pA25Uq6pzY2n9DvO/nEU++dPXW4Rw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -114,7 +114,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.1"
+        "semver": "^7.8.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -129,7 +129,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -3693,10 +3693,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.261.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.261.0.tgz",
-      "integrity": "sha512-e52e3Abjg0HkuRWlWwtSv5+ZiMW1rhCDdL9ff7lzWXInU8xdfLJpuoimfa0IJwjiNGyphppgg52Azx9M80OA0g==",
+      "version": "2.262.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.1.tgz",
+      "integrity": "sha512-B6YP4r6ojUZCDhl+qBu/CrWzcipR8sIgshcqYvgw013sghPXmVkYdJ3yuI9+DKML3YLSjQrHy1nGJs+Nqq7JCg==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -3713,17 +3714,18 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.282",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
-        "@aws-cdk/cloud-assembly-api": "^2.2.5",
-        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.5.1-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.8.1",
+        "semver": "^7.8.5",
         "yaml": "1.10.3"
       },
       "engines": {
@@ -3734,18 +3736,26 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.5.1-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -3762,7 +3772,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3781,7 +3791,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.5",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3867,7 +3877,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5827,7 +5837,6 @@
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
       "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6074,7 +6083,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -7383,7 +7391,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -11161,7 +11168,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12313,7 +12319,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.34.0",
     "@types/aws-lambda": "^8.10.162",
-    "aws-cdk-lib": "2.261.0",
+    "aws-cdk-lib": "2.262.1",
     "axios": "^1.18.1",
     "constructs": "^10.7.1",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
Closes Dependabot alert [#46](https://github.com/sturman/bus-lviv-bot/security/dependabot/46) — brace-expansion GHSA-3jxr-9vmj-r5cp / CVE-2026-13149, high.

Follow-up to #489, which fixed the `jest` → `glob` copy. This one addresses the copy that a lockfile update cannot reach.

## Why a version bump is the only option here

`aws-cdk-lib` publishes its dependencies **inside its own tarball** via `bundleDependencies`. npm unpacks that copy verbatim, so it is never resolved from the registry, never deduped against the top-level `brace-expansion@5.0.8`, and untouchable by `npm update`, `npm audit fix`, or `overrides`:

```
5.0.6   bundled=true   dev=false   node_modules/aws-cdk-lib/node_modules/brace-expansion   ← the alert
5.0.8   bundled=false  dev=true    node_modules/brace-expansion
2.1.2   bundled=false  dev=true    node_modules/glob/node_modules/brace-expansion          ← fixed in #489
5.0.7   bundled=true   dev=true    node_modules/npm/node_modules/brace-expansion
1.1.16  bundled=false  dev=true    node_modules/test-exclude/node_modules/brace-expansion
```

2.262.1 bundles **5.0.7**, satisfying the advisory's `>= 5.0.7`.

## Alert #49 is not fixed by this and stays open

[#49](https://github.com/sturman/bus-lviv-bot/security/dependabot/49) is a **second, distinct advisory** — GHSA-mh99-v99m-4gvg / CVE-2026-14257, OOM crash, published 2026-07-24 — against the same bundled copy:

| Alert | Advisory | Needs | 2.261.0 | 2.262.1 |
|---|---|---|---|---|
| #46 | GHSA-3jxr-9vmj-r5cp | ≥ 5.0.7 | 5.0.6 ❌ | 5.0.7 ✅ |
| #49 | GHSA-mh99-v99m-4gvg | ≥ **5.0.8** | 5.0.6 ❌ | 5.0.7 ❌ |

2.262.1 is the latest aws-cdk-lib release and still bundles 5.0.7, so **no upgrade closes #49 today**. It needs an upstream release that re-bundles 5.0.8. Leaving it open so Dependabot picks it up automatically.

Worth noting for the risk call on #49: `aws-cdk-lib` is imported only by `bin/bus-lviv-bot.ts` and `lib/bus-lviv-bot-stack.ts`, i.e. synth/deploy time. Nothing under `functions/` imports it, so it never enters the Lambda bundle — the `runtime` scope on the alert reflects which `package.json` section it sits in, not production exposure.

## Infrastructure impact: none

Synthesized `BusLvivBotStack` template diffed against `main`. **29 lines, two hunks, no resource, property, or IAM changes:**

1. Lambda `S3Key` / `aws:asset:path` — asset hash moved
2. `CDKMetadata.Analytics` — the CDK version fingerprint blob

I unpacked both asset bundles to check the hash change is benign:

- **`index.js` is byte-identical** — `sha256:7920570e3d4e0f1eed9014e32d1f50d734b06fc6d9859dde9abde70e80430302` in both
- Identical file lists; the *only* differing file is the `package-lock.json` that `NodejsFunction` copies into the asset to install `nodeModules: ['@aws-lambda-powertools/logger']`. Its delta is just the `aws-cdk-lib` line plus transitive `@aws-cdk/cloud-assembly-schema` 54.2.0 → 54.14.0 and `semver` 7.8.1 → 7.8.5
- Shipped runtime deps in the bundle (powertools `logger`/`commons`, `@aws/lambda-invoke-store`) are unchanged

So merging redeploys the Lambda with functionally identical code under a new S3 key. Note `cdk:deploy` runs on every push to `main`, so this deploys on merge rather than waiting on a release — and since it is typed `chore`, semantic-release will not cut a version.

## Test plan

- [x] `npm install` — `package.json` + lockfile, aws-cdk-lib only
- [x] `npm run ts-check` — pass
- [x] `npm run eslint` — pass
- [x] `npm run test` — 37/37 across 4 suites
- [x] `npm run cdk:synth` — succeeds, 11 unconfigured feature flags (pre-existing, unchanged)
- [x] Template diff vs `main` — asset hash + CDK metadata only
- [x] Asset bundle diff vs `main` — `index.js` byte-identical
- [x] `npm ls brace-expansion --all` — aws-cdk-lib copy now 5.0.7
- [ ] CI green, including the `diff` job against the live stack

`npm run prettier:check:ci` flags only `.claude/settings.local.json`, gitignored and absent in CI.
